### PR TITLE
Enable multilingual support

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,12 @@
             }
         }
     </style>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'fr', includedLanguages: 'fr,en,es'}, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">
@@ -297,6 +303,7 @@
                 <a href="index.html#blog" class="font-medium hover:text-blue-600 transition">Blog</a>
                 <a href="index.html#contact" class="font-medium hover:text-blue-600 transition">Contact</a>
             </nav>
+            <div id="google_translate_element"></div>
             <button id="mobileMenuButton" class="md:hidden text-gray-700 mobile-menu-button">
                 <i class="fas fa-bars text-2xl"></i>
             </button>

--- a/pack1.html
+++ b/pack1.html
@@ -83,6 +83,12 @@
             transform: translateY(0);
         }
     </style>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'fr', includedLanguages: 'fr,en,es'}, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </head>
 <body class="bg-gray-50 text-gray-900">
     <!-- Header -->
@@ -100,6 +106,7 @@
                 <a href="index.html#blog" class="font-medium hover:text-blue-600 transition">Blog</a>
                 <a href="index.html#contact" class="font-medium hover:text-blue-600 transition">Contact</a>
             </nav>
+            <div id="google_translate_element"></div>
             <button id="mobileMenuButton" class="md:hidden text-gray-700 mobile-menu-button">
                 <i class="fas fa-bars text-2xl"></i>
             </button>

--- a/pack2.html
+++ b/pack2.html
@@ -275,6 +275,12 @@
             }
         }
     </style>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'fr', includedLanguages: 'fr,en,es'}, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">
@@ -293,6 +299,7 @@
                 <a href="index.html#blog" class="font-medium hover:text-blue-600 transition">Blog</a>
                 <a href="index.html#contact" class="font-medium hover:text-blue-600 transition">Contact</a>
             </nav>
+            <div id="google_translate_element"></div>
             <button id="mobileMenuButton" class="md:hidden text-gray-700 mobile-menu-button">
                 <i class="fas fa-bars text-2xl"></i>
             </button>

--- a/pack3.html
+++ b/pack3.html
@@ -91,6 +91,12 @@
             margin-bottom: 1rem;
         }
     </style>
+    <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'fr', includedLanguages: 'fr,en,es'}, 'google_translate_element');
+    }
+    </script>
+    <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </head>
 <body class="bg-gray-50 text-gray-900">
     <!-- Header -->
@@ -108,6 +114,7 @@
                 <a href="index.html#blog" class="font-medium hover:text-blue-600 transition">Blog</a>
                 <a href="index.html#contact" class="font-medium hover:text-blue-600 transition">Contact</a>
             </nav>
+            <div id="google_translate_element"></div>
             <button id="mobileMenuButton" class="md:hidden text-gray-700 mobile-menu-button">
                 <i class="fas fa-bars text-2xl"></i>
             </button>


### PR DESCRIPTION
## Summary
- add Google Translate widget for French, English and Spanish translations
- place language selector in each page header

## Testing
- `bash formation-volvic/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68404e3c9a50832dbe4eb67c3ba1e3b9