### PR TITLE
Improve markdown chat rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Le dossier `chatbot/` permet de démarrer un service Flask qui fournit un chatbo
 
 Une fois démarré, le service écoute par défaut sur le port `5000`.
 
+### Affichage enrichi
+
+Le widget de discussion affiche désormais les réponses caractère par caractère
+avant de les convertir en **Markdown** sécurisé. Cela permet d'inclure des
+listes, du texte en gras ou des liens cliquables dans la conversation tout en
+conservant l'effet de frappe.
+
 ## Autres dossiers
 
 - `envoimail/` : petit exemple d'envoi d'e-mail avec Flask. Les variables d'environnement `EMAIL_EXPEDITEUR`, `EMAIL_DESTINATAIRE`, `GMAIL_APP_PASSWORD` et `SECRET_KEY` doivent être définies.

--- a/chatbot-frame.html
+++ b/chatbot-frame.html
@@ -19,8 +19,8 @@
       width: 350px;
       height: 500px;
       background: white;
-      border-radius: 0
-      box-shadow: none
+      border-radius: 0;
+      box-shadow: none;
       overflow: hidden;
       display: flex;
       flex-direction: column;
@@ -155,16 +155,21 @@
     chatbotMessages.appendChild(message);
     chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
 
-    // Sépare par mots (pour lettre à lettre, change en split(''))
-    const words = text.split(' ');
-    for (let i = 0; i < words.length; i++) {
-      // Rendu markdown/dompurify si tu veux, mais ici simple :
-      message.innerHTML += (i > 0 ? ' ' : '') + DOMPurify.sanitize(words[i]);
+    // Animation caractère par caractère pour un effet de frappe
+    let partial = '';
+    const chars = text.split('');
+    for (let i = 0; i < chars.length; i++) {
+      partial += chars[i];
+      // Affiche le texte brut pendant la frappe
+      message.textContent = partial;
       chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
       await new Promise(res => setTimeout(res, delay));
-    
-    
     }
+
+    // Une fois l'animation terminée, applique le rendu Markdown
+    const raw = md.render(partial);
+    message.innerHTML = DOMPurify.sanitize(raw);
+    chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
   }
 
 

--- a/index.html
+++ b/index.html
@@ -1008,20 +1008,25 @@
   
   const md = window.markdownit({ linkify: true, typographer: true });
   
-  // Animation mot par mot (ou lettre par lettre)
+  // Animation caractère par caractère puis rendu Markdown complet
   async function addMessageAnimated(text, isUser = false, delay = 60) {
     const message = document.createElement('div');
     message.className = 'message ' + (isUser ? 'user-message' : 'bot-message');
     chatbotMessages.appendChild(message);
     chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
-  
-    // ANIMATION MOT PAR MOT (change .split(' ') en .split('') pour lettre à lettre)
-    const words = text.split(' ');
-    for (let i = 0; i < words.length; i++) {
-      message.innerHTML += (i > 0 ? ' ' : '') + DOMPurify.sanitize(words[i]);
+
+    let partial = '';
+    const chars = text.split('');
+    for (let i = 0; i < chars.length; i++) {
+      partial += chars[i];
+      message.textContent = partial;
       chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
       await new Promise(res => setTimeout(res, delay));
     }
+
+    const raw = md.render(partial);
+    message.innerHTML = DOMPurify.sanitize(raw);
+    chatbotMessages.scrollTop = chatbotMessages.scrollHeight;
   }
   
   // Message utilisateur instantané


### PR DESCRIPTION
## Summary
- animate responses one character at a time then render Markdown
- sanitize and render Markdown for the iframe widget as well
- fix missing CSS semicolons in `chatbot-frame.html`
- document Markdown rendering in README

## Testing
- `python -m py_compile chatbot/app.py chatbot/backend/openrouter_api.py chatbot/backend/rag.py chatbot/fix.py envoimail/pythonemail.py envoimail/app.py`


------
https://chatgpt.com/codex/tasks/task_b_68654ad45484832dba84dafd66d89c11