### PR TITLE
Ajout de tests et workflow CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r chatbot/requirement.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ conservant l'effet de frappe.
 - `formation-volvic/` : projet d'inscription à une formation. Reportez-vous au fichier [`formation-volvic/README.md`](formation-volvic/README.md) pour toutes les instructions détaillées.
 - `rlv/` : site vitrine pour présenter différents POC, documenté dans [`rlv/documentation.md`](rlv/documentation.md).
 
+## Tests
+
+Une petite suite de tests `pytest` vérifie le fonctionnement du processeur RAG.
+Pour les lancer localement :
+
+```bash
+pip install -r chatbot/requirement.txt pytest
+pytest
+```
+
+Un workflow GitHub Actions exécute automatiquement ces tests à chaque poussée
+ou pull request sur la branche `main`.
+
 ## Licence
 
 Aucune licence spécifique n'est fournie avec ce dépôt.

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,15 @@
+import os
+from chatbot.backend.rag import RAGProcessor
+
+
+def test_get_relevant_context_contains_keyword():
+    rag = RAGProcessor()
+    context = rag.get_relevant_context("Auvergne")
+    assert "Auvergne" in context
+
+
+def test_get_relevant_context_is_string():
+    rag = RAGProcessor()
+    context = rag.get_relevant_context("IAfluence")
+    assert isinstance(context, str)
+    assert "IAfluence" in context


### PR DESCRIPTION
## Summary
- add `pytest` tests for RAG processor
- set up GitHub Actions workflow to run tests
- document how to run tests and mention CI in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686567447e9c832dae765f9e07ab4a93